### PR TITLE
Solve Cabal dependency issue

### DIFF
--- a/ShootEmUp/Game/ShootEmUp.cabal
+++ b/ShootEmUp/Game/ShootEmUp.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 executable ShootEmUp
   main-is:             Main.hs
   build-depends:       base >= 4 && < 5,
-                       gloss,
+                       gloss == 1.13.2.1,
                        random,
                        directory
   hs-source-dirs:      src


### PR DESCRIPTION
This should finally solve the Cabal issue.
Please update Cabal first, the problem was that Stack was using an old version of Gloss by default. 
